### PR TITLE
feat: add 'Create Issue' button to spend insights for pipeline improvement

### DIFF
--- a/src/issue-mapper.js
+++ b/src/issue-mapper.js
@@ -1,0 +1,229 @@
+'use strict';
+
+/**
+ * Maps spend-analysis insights to GitHub issue structures.
+ * Each actionable insight produces { title, body, labels } suitable for `gh issue create`.
+ * Non-actionable insights (day-pattern, project-dominance) return null.
+ */
+
+const INSIGHT_MAPPINGS = {
+  'vague-prompts': {
+    titlePrefix: 'Reduce token waste from vague prompts',
+    labels: ['spend-analysis', 'token-efficiency'],
+    targetFiles: ['.claude/skills/using-skills/SKILL.md'],
+    section: 'Token Awareness',
+    tasks: [
+      { agent: 'default', size: 'S', desc: 'Add prompt specificity examples to using-skills/SKILL.md' },
+      { agent: 'default', size: 'S', desc: 'Add "vague prompt" anti-patterns with before/after examples to Token Awareness section' },
+      { agent: 'default', size: 'S', desc: 'Document token cost multiplier effect of ambiguous instructions' },
+    ],
+    acceptanceCriteria: [
+      'Token Awareness section in using-skills/SKILL.md includes at least 3 before/after prompt examples',
+      'Anti-patterns section covers short vague messages like "Yes", "Do it", "Fix it"',
+      'Cost impact explanation is included showing how vague prompts trigger extra tool calls',
+    ],
+  },
+
+  'context-growth': {
+    titlePrefix: 'Mitigate context growth in long conversations',
+    labels: ['spend-analysis', 'token-efficiency'],
+    targetFiles: [
+      '.claude/skills/subagent-driven-development/SKILL.md',
+      '.claude/skills/executing-plans/SKILL.md',
+    ],
+    section: 'Context Management',
+    tasks: [
+      { agent: 'default', size: 'M', desc: 'Add conversation splitting guidelines to subagent-driven-development/SKILL.md' },
+      { agent: 'default', size: 'S', desc: 'Add context summary handoff pattern to executing-plans/SKILL.md' },
+      { agent: 'default', size: 'S', desc: 'Document when to start fresh conversations vs continue existing ones' },
+    ],
+    acceptanceCriteria: [
+      'subagent-driven-development/SKILL.md includes conversation splitting guidelines',
+      'executing-plans/SKILL.md includes context summary handoff pattern',
+      'Guidelines specify token thresholds or message counts as splitting triggers',
+    ],
+  },
+
+  'marathon-sessions': {
+    titlePrefix: 'Reduce cost of marathon coding sessions',
+    labels: ['spend-analysis', 'token-efficiency'],
+    targetFiles: ['.claude/skills/using-skills/SKILL.md'],
+    section: 'Session Management',
+    tasks: [
+      { agent: 'default', size: 'S', desc: 'Add session length guidelines to using-skills/SKILL.md' },
+      { agent: 'default', size: 'S', desc: 'Document task-per-conversation pattern with recommended message limits' },
+      { agent: 'default', size: 'S', desc: 'Add session checkpoint/handoff instructions for long-running work' },
+    ],
+    acceptanceCriteria: [
+      'using-skills/SKILL.md includes recommended session length limits',
+      'Task-per-conversation pattern is documented with examples',
+      'Checkpoint/handoff instructions enable resuming work in fresh sessions',
+    ],
+  },
+
+  'model-mismatch': {
+    titlePrefix: 'Optimize model selection for simple tasks',
+    labels: ['spend-analysis', 'cost-optimization'],
+    targetFiles: ['.claude/scripts/model-config.sh'],
+    section: 'Model Configuration',
+    tasks: [
+      { agent: 'default', size: 'M', desc: 'Create or update .claude/scripts/model-config.sh with task-complexity routing rules' },
+      { agent: 'default', size: 'S', desc: 'Add model selection decision tree (Opus for complex, Sonnet for standard, Haiku for simple)' },
+      { agent: 'default', size: 'S', desc: 'Document /model switch patterns for common task types' },
+    ],
+    acceptanceCriteria: [
+      'model-config.sh includes task-complexity routing configuration',
+      'Decision tree covers at least 3 complexity tiers with model recommendations',
+      'Common task types (quick questions, refactoring, architecture) are mapped to models',
+    ],
+  },
+
+  'tool-heavy': {
+    titlePrefix: 'Reduce excessive tool calls in agent workflows',
+    labels: ['spend-analysis', 'agent-optimization'],
+    targetFiles: ['.claude/agents/'],
+    section: 'Tool Usage Optimization',
+    tasks: [
+      { agent: 'default', size: 'M', desc: 'Audit agent .md files in .claude/agents/ for missing file path guidance' },
+      { agent: 'default', size: 'S', desc: 'Add specific file targeting instructions to reduce exploratory tool calls' },
+      { agent: 'default', size: 'S', desc: 'Document tool call reduction patterns (explicit paths, line numbers, grep before read)' },
+    ],
+    acceptanceCriteria: [
+      'Agent definition files include file path guidance where applicable',
+      'Tool call reduction patterns are documented with examples',
+      'Before/after comparison shows expected tool call reduction',
+    ],
+  },
+
+  'heavy-context': {
+    titlePrefix: 'Reduce startup context overhead',
+    labels: ['spend-analysis', 'token-efficiency'],
+    targetFiles: ['.claude/skills/adapting-claude-pipeline/SKILL.md'],
+    section: 'Token Efficiency Audit',
+    tasks: [
+      { agent: 'default', size: 'M', desc: 'Add Token Efficiency Audit checklist to adapting-claude-pipeline/SKILL.md' },
+      { agent: 'default', size: 'S', desc: 'Document CLAUDE.md pruning guidelines with size benchmarks' },
+      { agent: 'default', size: 'S', desc: 'Add instructions for splitting large CLAUDE.md into focused skill files' },
+    ],
+    acceptanceCriteria: [
+      'adapting-claude-pipeline/SKILL.md includes Token Efficiency Audit section',
+      'CLAUDE.md pruning guidelines specify target size ranges',
+      'Splitting strategy documents how to decompose monolithic config into skills',
+    ],
+  },
+
+  'conversation-efficiency': {
+    titlePrefix: 'Improve conversation efficiency ratio',
+    labels: ['spend-analysis', 'token-efficiency'],
+    targetFiles: ['.claude/skills/using-skills/SKILL.md'],
+    section: 'Conversation Efficiency',
+    tasks: [
+      { agent: 'default', size: 'S', desc: 'Add conversation efficiency guidelines to using-skills/SKILL.md' },
+      { agent: 'default', size: 'S', desc: 'Document cost-per-message growth curve and why shorter conversations save tokens' },
+      { agent: 'default', size: 'S', desc: 'Add practical message count targets for different task types' },
+    ],
+    acceptanceCriteria: [
+      'using-skills/SKILL.md includes conversation efficiency section',
+      'Cost growth explanation covers the re-reading multiplier effect',
+      'Message count targets are provided for at least 3 task categories',
+    ],
+  },
+
+  'input-heavy': {
+    titlePrefix: 'Address high input-to-output token ratio',
+    labels: ['spend-analysis', 'token-efficiency'],
+    targetFiles: [],
+    section: 'Output Optimization',
+    linkedIssue: 45,
+    tasks: [
+      { agent: 'default', size: 'S', desc: 'Link to and coordinate with issue #45 (output truncation)' },
+      { agent: 'default', size: 'S', desc: 'Document input/output ratio awareness and its implications for session planning' },
+    ],
+    acceptanceCriteria: [
+      'Issue is linked to #45 with cross-reference',
+      'Input/output ratio implications are documented for session planning',
+    ],
+  },
+};
+
+// Non-actionable insight IDs that should return null
+const SKIP_IDS = new Set(['day-pattern', 'project-dominance']);
+
+/**
+ * Maps an insight object to a GitHub issue structure.
+ *
+ * @param {Object} insight - Insight from the parser
+ * @param {string} insight.id - Insight identifier
+ * @param {string} insight.type - 'warning' | 'info' | 'neutral'
+ * @param {string} insight.title - Human-readable title
+ * @param {string} insight.description - Detailed description
+ * @param {string|null} insight.action - Suggested action or null
+ * @returns {{ title: string, body: string, labels: string[] } | null}
+ */
+function mapInsightToIssue(insight) {
+  if (!insight || !insight.id) return null;
+  if (SKIP_IDS.has(insight.id)) return null;
+
+  const mapping = INSIGHT_MAPPINGS[insight.id];
+  if (!mapping) return null;
+
+  const title = `[spend-analysis] ${mapping.titlePrefix}`;
+
+  const contextLines = [
+    '## Context',
+    '',
+    '> Auto-generated from [claude-spend](https://github.com/shinytrap/claude-spend) spend analysis.',
+    '',
+    `**Insight type:** \`${insight.type}\``,
+    `**Insight:** ${insight.title}`,
+    '',
+    insight.description,
+    '',
+  ];
+
+  if (insight.action) {
+    contextLines.push(`**Recommended action:** ${insight.action}`);
+    contextLines.push('');
+  }
+
+  if (mapping.targetFiles.length > 0) {
+    contextLines.push('**Target files:**');
+    for (const f of mapping.targetFiles) {
+      contextLines.push(`- \`${f}\``);
+    }
+    contextLines.push('');
+  }
+
+  if (mapping.linkedIssue) {
+    contextLines.push(`**Related:** #${mapping.linkedIssue}`);
+    contextLines.push('');
+  }
+
+  const taskLines = [
+    '## Implementation Tasks',
+    '',
+  ];
+  for (const task of mapping.tasks) {
+    taskLines.push(`- [ ] \`[${task.agent}]\` **(${task.size})** ${task.desc}`);
+  }
+  taskLines.push('');
+
+  const acLines = [
+    '## Acceptance Criteria',
+    '',
+  ];
+  for (const ac of mapping.acceptanceCriteria) {
+    acLines.push(`- [ ] ${ac}`);
+  }
+  acLines.push('');
+
+  const body = [...contextLines, ...taskLines, ...acLines].join('\n');
+
+  return {
+    title,
+    body,
+    labels: mapping.labels,
+  };
+}
+
+module.exports = { mapInsightToIssue };

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -297,7 +297,7 @@
   .insight-expand {
     max-height: 0; overflow: hidden; transition: max-height 0.3s ease;
   }
-  .insight-card.expanded .insight-expand { max-height: 300px; }
+  .insight-card.expanded .insight-expand { max-height: 500px; }
   .insight-detail {
     font-size: 13px; color: var(--text-secondary); line-height: 1.65;
     padding: 12px 0 4px 40px;
@@ -306,6 +306,31 @@
   .insight-action-tip {
     font-size: 13px; line-height: 1.6;
     padding: 8px 0 0 40px; color: var(--indigo); font-weight: 600;
+  }
+  .insight-create-issue {
+    padding: 8px 0 4px 40px; display: flex; align-items: center; gap: 8px;
+  }
+  .insight-create-issue button {
+    font-size: 12px; font-weight: 600; padding: 6px 14px;
+    border: 1px solid var(--indigo); border-radius: var(--radius-sm);
+    background: var(--white); color: var(--indigo); cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .insight-create-issue button:hover { background: var(--indigo); color: var(--white); }
+  .insight-create-issue button:disabled { opacity: 0.5; cursor: default; pointer-events: none; }
+  .insight-create-issue .issue-status {
+    font-size: 12px; font-weight: 500;
+  }
+  .insight-create-issue .issue-status a { color: var(--indigo); text-decoration: underline; }
+  .insight-create-issue .issue-status.duplicate { color: var(--amber); }
+  .insight-create-issue .issue-status.error { color: #EF4444; }
+  .insight-repo-config {
+    padding: 4px 0 8px 40px; display: flex; align-items: center; gap: 8px;
+  }
+  .insight-repo-config label { font-size: 11px; color: var(--text-tertiary); font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+  .insight-repo-config input {
+    font-size: 12px; padding: 4px 8px; border: 1px solid var(--border);
+    border-radius: var(--radius-sm); width: 260px; font-family: var(--mono);
   }
 
   /* ---- CHARTS ---- */
@@ -639,6 +664,10 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="#D97706" stroke-width="2.5" stroke-linecap="round"><path d="M12 2a7 7 0 0 1 4 12.75V17a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1v-2.25A7 7 0 0 1 12 2z"/><path d="M9 21h6"/></svg>
       </div>
       <div class="section-title">Insights</div>
+    </div>
+    <div class="insight-repo-config">
+      <label>Target repo</label>
+      <input type="text" id="issueTargetRepo" value="stevegrocott/claude-pipeline" placeholder="owner/repo">
     </div>
     <div id="insightsList"></div>
   </div>
@@ -1221,9 +1250,14 @@ function renderInsights() {
   const icons = { warning: '!', info: 'i', neutral: '~' };
   const emojis = { warning: '\u26A0\uFE0F', info: '\uD83D\uDCA1', neutral: '\uD83D\uDCC5' };
 
+  const skipIds = new Set(['day-pattern', 'project-dominance']);
   document.getElementById('insightsList').innerHTML = insights.map((ins, i) => {
     const detailHtml = ins.description ? `<div class="insight-detail">${escapeHtml(ins.description)}</div>` : '';
     const actionHtml = ins.action ? `<div class="insight-action-tip">${escapeHtml(ins.action)}</div>` : '';
+    const buttonHtml = !skipIds.has(ins.id) ? `<div class="insight-create-issue">
+        <button id="btn-${ins.id}" onclick="event.stopPropagation(); createIssueFromInsight('${ins.id}', this)">Create Issue</button>
+        <span class="issue-status" id="status-${ins.id}"></span>
+      </div>` : '';
     return `<div class="insight-card ${ins.type} animate delay-${Math.min(i + 2, 5)}" onclick="this.classList.toggle('expanded')">
       <div class="insight-top">
         <div class="insight-indicator">${emojis[ins.type] || ''}</div>
@@ -1233,9 +1267,50 @@ function renderInsights() {
       <div class="insight-expand">
         ${detailHtml}
         ${actionHtml}
+        ${buttonHtml}
       </div>
     </div>`;
   }).join('');
+}
+
+async function createIssueFromInsight(insightId, btn) {
+  const repo = document.getElementById('issueTargetRepo').value.trim();
+  if (!repo) { alert('Please set a target repo'); return; }
+
+  const statusEl = document.getElementById('status-' + insightId);
+  btn.disabled = true;
+  btn.textContent = 'Creating...';
+  statusEl.className = 'issue-status';
+  statusEl.innerHTML = '';
+
+  try {
+    const resp = await fetch('/api/create-issue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ insightId, repo }),
+    });
+    const data = await resp.json();
+
+    if (data.duplicate) {
+      statusEl.className = 'issue-status duplicate';
+      statusEl.innerHTML = `Already exists: <a href="${data.existingUrl}" target="_blank">#${data.number}</a>`;
+      btn.textContent = 'Duplicate';
+    } else if (data.created) {
+      statusEl.className = 'issue-status';
+      statusEl.innerHTML = `Created: <a href="${data.url}" target="_blank">#${data.number}</a>`;
+      btn.textContent = 'Created';
+    } else if (data.error) {
+      statusEl.className = 'issue-status error';
+      statusEl.textContent = data.error;
+      btn.disabled = false;
+      btn.textContent = 'Create Issue';
+    }
+  } catch (err) {
+    statusEl.className = 'issue-status error';
+    statusEl.textContent = 'Network error: ' + err.message;
+    btn.disabled = false;
+    btn.textContent = 'Create Issue';
+  }
 }
 
 // Daily chart

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,11 @@
 const express = require('express');
 const path = require('path');
+const { execSync } = require('child_process');
+const { mapInsightToIssue } = require('./issue-mapper');
+
 function createServer() {
   const app = express();
+  app.use(express.json());
 
   // Cache parsed data (reparse on demand via refresh endpoint)
   let cachedData = null;
@@ -24,6 +28,79 @@ function createServer() {
       res.json({ ok: true, sessions: cachedData.sessions.length });
     } catch (err) {
       res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.post('/api/create-issue', async (req, res) => {
+    const { insightId, repo, dryRun } = req.body;
+
+    if (!insightId || !repo) {
+      return res.status(400).json({ error: 'insightId and repo are required' });
+    }
+
+    // Ensure we have cached data with insights
+    try {
+      if (!cachedData) {
+        cachedData = await require('./parser').parseAllSessions();
+      }
+    } catch (err) {
+      return res.status(500).json({ error: 'Failed to parse sessions: ' + err.message });
+    }
+
+    // Find the insight by ID
+    const insight = (cachedData.insights || []).find(i => i.id === insightId);
+    if (!insight) {
+      return res.status(404).json({ error: `Insight "${insightId}" not found in current data` });
+    }
+
+    // Map insight to issue structure
+    const issue = mapInsightToIssue(insight);
+    if (!issue) {
+      return res.status(400).json({ error: `Insight "${insightId}" is not actionable` });
+    }
+
+    // Dry run — return what would be created
+    if (dryRun) {
+      return res.json({ dryRun: true, title: issue.title, body: issue.body, labels: issue.labels });
+    }
+
+    // Check gh CLI availability
+    try {
+      execSync('gh --version', { stdio: 'pipe' });
+    } catch {
+      return res.status(500).json({ error: 'gh CLI not found. Install: https://cli.github.com/' });
+    }
+
+    // Dedup check — look for open issues with same title
+    try {
+      const existing = execSync(
+        `gh issue list --repo ${repo} --label spend-analysis --state open --json title,number,url`,
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      );
+      const openIssues = JSON.parse(existing || '[]');
+      const duplicate = openIssues.find(i => i.title === issue.title);
+      if (duplicate) {
+        return res.json({ duplicate: true, existingUrl: duplicate.url, number: duplicate.number });
+      }
+    } catch (err) {
+      // Label might not exist yet — that's fine, no duplicates
+      if (!err.message.includes('label')) {
+        return res.status(500).json({ error: 'Dedup check failed: ' + err.message });
+      }
+    }
+
+    // Create the issue
+    try {
+      const labelArgs = issue.labels.map(l => `--label "${l}"`).join(' ');
+      const result = execSync(
+        `gh issue create --repo ${repo} --title "${issue.title.replace(/"/g, '\\"')}" ${labelArgs} --body -`,
+        { input: issue.body, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      );
+      const url = result.trim();
+      const number = parseInt(url.split('/').pop(), 10);
+      return res.json({ created: true, url, number });
+    } catch (err) {
+      return res.status(500).json({ error: 'Issue creation failed: ' + err.message });
     }
   });
 


### PR DESCRIPTION
## Summary

- Adds "Create Issue" buttons to dashboard insight cards, connecting spend analysis directly to pipeline improvement issues
- New `issue-mapper.js` maps 8 actionable insight types to structured GitHub Issues following the claude-pipeline's parseable format
- New `POST /api/create-issue` endpoint with dedup checking via `gh` CLI
- Target repo configurable in dashboard (defaults to `stevegrocott/claude-pipeline`)

Closes stevegrocott/claude-pipeline#47

## Test plan

- [ ] Run `npx claude-spend` and verify dashboard loads with insights
- [ ] Verify "Create Issue" buttons appear on actionable insights (not on day-pattern/project-dominance)
- [ ] Click "Create Issue" and verify issue created on target repo with correct format
- [ ] Click same button again and verify duplicate detection
- [ ] Verify created issue body is parseable by `/implement-issue` orchestrator

Generated with [Claude Code](https://claude.com/claude-code)