### PR TITLE
fix: Use system local timezone for session dates

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -168,7 +168,11 @@ async function parseAllSessions() {
       const totalTokens = inputTokens + outputTokens;
 
       const firstTimestamp = entries.find(e => e.timestamp)?.timestamp;
-      const date = firstTimestamp ? firstTimestamp.split('T')[0] : 'unknown';
+      let date = 'unknown';
+      if (firstTimestamp) {
+        const d = new Date(firstTimestamp);
+        date = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      }
 
       // Primary model
       const modelCounts = {};


### PR DESCRIPTION
## Summary
- Session dates were derived from UTC timestamps via `split('T')[0]`, assigning sessions near midnight local time to the wrong day
- Now uses `new Date()` which converts to the system's local timezone before extracting YYYY-MM-DD

## Test plan
- [x] All 49 Playwright tests pass
- [x] Date format remains YYYY-MM-DD (no downstream breakage)

Closes #17

🤖 Generated with [Claude Code](https://claude.ai/claude-code)