### PR TITLE
fix: align chart X-axes across session and pipeline data

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1984,11 +1984,26 @@ async function createIssueFromInsight(insightId, btn) {
 }
 
 // Pipeline data distributed across lens sections
+// Compute the shared date range across session and orchestrator data for a lens section.
+// Returns {from, to, totalDays} or null if no data.
+function getLensDateRange() {
+  const dates = [];
+  if (FILTERED && FILTERED.dailyUsage) FILTERED.dailyUsage.forEach(d => dates.push(d.date));
+  const orch = FILTERED ? (FILTERED.orchestrator || DATA.orchestrator) : DATA.orchestrator;
+  if (orch && orch.runs) orch.runs.forEach(r => { if (r.date) dates.push(r.date); });
+  if (dates.length === 0) return null;
+  dates.sort();
+  const from = dates[0];
+  const to = dates[dates.length - 1];
+  const totalDays = Math.round((new Date(to) - new Date(from)) / 86400000);
+  return { from, to, totalDays };
+}
+
 function renderMiniTimeSeries(canvasId, dailyData, opts) {
   const canvas = document.getElementById(canvasId);
   if (!canvas || !dailyData.length) return;
   const ctx = canvas.getContext('2d');
-  const { color = '#6366F1', format = (v) => String(Math.round(v)) } = opts || {};
+  const { color = '#6366F1', format = (v) => String(Math.round(v)), dateRange = null } = opts || {};
 
   const dpr = window.devicePixelRatio || 1;
   const w = canvas.parentElement.clientWidth - 32;
@@ -2015,7 +2030,18 @@ function renderMiniTimeSeries(canvasId, dailyData, opts) {
     ctx.fillText(format(val), startX - 4, y + 3);
   }
 
-  function xPos(i) { return startX + (i / Math.max(1, dailyData.length - 1)) * plotW; }
+  // When dateRange is provided, position by date within the shared range
+  const useSharedRange = dateRange && dateRange.totalDays > 0;
+  const rangeFromMs = useSharedRange ? new Date(dateRange.from).getTime() : 0;
+  const rangeTotalMs = useSharedRange ? (new Date(dateRange.to).getTime() - rangeFromMs) : 1;
+
+  function xPos(i) {
+    if (useSharedRange) {
+      const dateMs = new Date(dailyData[i].date).getTime();
+      return startX + ((dateMs - rangeFromMs) / rangeTotalMs) * plotW;
+    }
+    return startX + (i / Math.max(1, dailyData.length - 1)) * plotW;
+  }
   function yPos(v) { return chartH + 4 - (v / maxVal) * chartH; }
 
   // Line
@@ -2042,12 +2068,23 @@ function renderMiniTimeSeries(canvasId, dailyData, opts) {
   });
   ctx.stroke(); ctx.setLineDash([]);
 
-  // X labels
+  // X labels — use shared range endpoints if available
   ctx.fillStyle = '#94A3B8'; ctx.textAlign = 'center'; ctx.font = '500 10px Inter, system-ui';
-  const step = Math.max(1, Math.floor(dailyData.length / 5));
-  dailyData.forEach((d, i) => {
-    if (i % step === 0 || i === dailyData.length - 1) ctx.fillText(formatDate(d.date), xPos(i), h - 4);
-  });
+  if (useSharedRange) {
+    // Show ~5 evenly spaced labels across the full range
+    const labelCount = 5;
+    for (let i = 0; i <= labelCount; i++) {
+      const t = i / labelCount;
+      const ms = rangeFromMs + t * rangeTotalMs;
+      const x = startX + t * plotW;
+      ctx.fillText(formatDate(new Date(ms).toISOString().slice(0, 10)), x, h - 4);
+    }
+  } else {
+    const step = Math.max(1, Math.floor(dailyData.length / 5));
+    dailyData.forEach((d, i) => {
+      if (i % step === 0 || i === dailyData.length - 1) ctx.fillText(formatDate(d.date), xPos(i), h - 4);
+    });
+  }
 }
 
 function renderCostSection() {
@@ -2068,8 +2105,9 @@ function renderCostSection() {
     <div class="chart-card" style="padding:16px"><h3 class="has-tooltip has-tooltip-below" style="font-size:14px;margin:0 0 8px;display:inline-block">Error Rate % per Day<div class="tooltip">Percentage of runs that ended in error each day</div></h3><canvas id="costErrorRateChart"></canvas></div>
   </div>`;
   requestAnimationFrame(() => {
-    renderMiniTimeSeries('costRunsChart', runsPerDay, { color: '#6366F1', format: v => String(Math.round(v)) });
-    renderMiniTimeSeries('costErrorRateChart', errorRatePerDay, { color: '#EF4444', format: v => Math.round(v) + '%' });
+    const costDateRange = getLensDateRange();
+    renderMiniTimeSeries('costRunsChart', runsPerDay, { color: '#6366F1', format: v => String(Math.round(v)), dateRange: costDateRange });
+    renderMiniTimeSeries('costErrorRateChart', errorRatePerDay, { color: '#EF4444', format: v => Math.round(v) + '%', dateRange: costDateRange });
   });
 }
 
@@ -2141,7 +2179,7 @@ function renderSpeedSection() {
   if (topStages.length > 0) {
     requestAnimationFrame(() => {
       topStages.forEach((st, i) => {
-        renderMiniTimeSeries('stageChart' + i, st.dailyData, { color: stageColors[i], format: v => Math.round(v) + 'm' });
+        renderMiniTimeSeries('stageChart' + i, st.dailyData, { color: stageColors[i], format: v => Math.round(v) + 'm', dateRange: getLensDateRange() });
       });
     });
   }
@@ -2214,9 +2252,10 @@ function renderQualitySection() {
       </div>
     </div>`;
   requestAnimationFrame(() => {
-    renderMiniTimeSeries('qualityCompletionChart', completionData, { color: '#10B981', format: v => Math.round(v) + '%' });
-    renderMiniTimeSeries('qualityIterChart', qualityData, { color: '#F59E0B', format: v => Number(v.toFixed(1)) + '' });
-    renderMiniTimeSeries('testIterChart', testData, { color: '#6366F1', format: v => Number(v.toFixed(1)) + '' });
+    const qualityDateRange = getLensDateRange();
+    renderMiniTimeSeries('qualityCompletionChart', completionData, { color: '#10B981', format: v => Math.round(v) + '%', dateRange: qualityDateRange });
+    renderMiniTimeSeries('qualityIterChart', qualityData, { color: '#F59E0B', format: v => Number(v.toFixed(1)) + '', dateRange: qualityDateRange });
+    renderMiniTimeSeries('testIterChart', testData, { color: '#6366F1', format: v => Number(v.toFixed(1)) + '', dateRange: qualityDateRange });
   });
 }
 


### PR DESCRIPTION
## Summary
- Adds `getLensDateRange()` helper that computes a shared date range from both session `dailyUsage` and orchestrator `runs`
- Updates `renderMiniTimeSeries()` to accept optional `dateRange` param — when provided, X positions are calculated by date within the full range instead of by array index
- All 6 pipeline chart call sites (cost, speed, quality sections) now pass the shared date range

## Problem
Charts in the same lens section had mismatched X-axis time ranges because each chart independently scaled its X-axis to its own data array length. Session charts spanning ~40 days and pipeline charts spanning ~5 days would show completely different date ranges side by side.

## Test plan
- [ ] Open dashboard at localhost:3456
- [ ] Verify Cost section pipeline charts align with session charts
- [ ] Verify Speed section stage duration charts align with session charts
- [ ] Verify Quality section completion/iteration charts align with session charts
- [ ] Confirm charts with no pipeline data still render correctly (fallback to index-based positioning)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)