### PR TITLE
fix(dashboard): add no_changes state to failure breakdown chart

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1369,7 +1369,7 @@ function computePPMTAnalysis(runs, dailyUsage) {
   }
 
   // 3. failureBreakdown — counts by failure type
-  const failureBreakdown = { parse_failure: 0, error: 0, max_iterations_pr_review: 0, running: 0, other: 0 };
+  const failureBreakdown = { parse_failure: 0, error: 0, max_iterations_pr_review: 0, running: 0, no_changes: 0, other: 0 };
   for (const run of runs) {
     if (run.state === 'error' && run.taskCount === 0) {
       failureBreakdown.parse_failure++;
@@ -1379,6 +1379,8 @@ function computePPMTAnalysis(runs, dailyUsage) {
       failureBreakdown.max_iterations_pr_review++;
     } else if (run.state === 'running') {
       failureBreakdown.running++;
+    } else if (run.state === 'no_changes') {
+      failureBreakdown.no_changes++;
     } else if (run.state !== 'completed') {
       failureBreakdown.other++;
     }

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -1398,12 +1398,13 @@ function recomputePpmtAnalysis(runs, sessionEff) {
   for (const size of ['S', 'M', 'L']) { const s = taskSizeCompletion[size]; s.total = s.completed + s.failed; s.rate = s.total > 0 ? Math.round((s.completed / s.total) * 100) : 0; }
 
   // failureBreakdown
-  const failureBreakdown = { parse_failure: 0, error: 0, max_iterations_pr_review: 0, running: 0, other: 0 };
+  const failureBreakdown = { parse_failure: 0, error: 0, max_iterations_pr_review: 0, running: 0, no_changes: 0, other: 0 };
   for (const run of validRuns) {
     if (run.state === 'error' && run.taskCount === 0) failureBreakdown.parse_failure++;
     else if (run.state === 'error') failureBreakdown.error++;
     else if (run.state === 'max_iterations_pr_review') failureBreakdown.max_iterations_pr_review++;
     else if (run.state === 'running') failureBreakdown.running++;
+    else if (run.state === 'no_changes') failureBreakdown.no_changes++;
     else if (run.state !== 'completed') failureBreakdown.other++;
   }
 
@@ -2209,6 +2210,7 @@ function renderFailureChart(breakdown) {
     { key: 'max_iterations_pr_review', label: 'Max Iterations', color: '#F59E0B' },
     { key: 'error', label: 'Error', color: '#F97316' },
     { key: 'running', label: 'Still Running', color: '#94A3B8' },
+    { key: 'no_changes', label: 'No Changes', color: '#94A3B8' },
     { key: 'other', label: 'Other', color: '#CBD5E1' },
   ].map(item => ({ ...item, count: breakdown[item.key] || 0 }))
    .filter(item => item.count > 0);


### PR DESCRIPTION
## Summary
- Add `no_changes: 0` to `failureBreakdown` in `parser.js` and `index.html`
- Route `run.state === 'no_changes'` to its own counter (not `other`)
- Add `{ key: 'no_changes', label: 'No Changes', color: '#94A3B8' }` to `renderFailureChart` items

Companion to stevegrocott/claude-pipeline#117 — the orchestrator now exits with `state: "no_changes"` instead of `state: "error"` when a branch has 0 commits. This change gives that state a visible category in the dashboard.

## Test plan
- [ ] Dashboard shows `No Changes` as a distinct bar in the failure breakdown chart
- [ ] Runs with `state: "no_changes"` no longer counted as `other`

🤖 Generated with [Claude Code](https://claude.com/claude-code)